### PR TITLE
Add descending search for finding dbt project root

### DIFF
--- a/analysis/state.go
+++ b/analysis/state.go
@@ -14,11 +14,12 @@ import (
 )
 
 type State struct {
-	mu            sync.RWMutex
-	Documents     map[string]Document
-	DbtContext    DbtContext
-	FusionEnabled bool
-	FusionPath    string
+	mu                sync.RWMutex
+	Documents         map[string]Document
+	DbtContext        DbtContext
+	FusionEnabled     bool
+	FusionPath        string
+	LspClientRootPath string
 }
 
 type Document struct {
@@ -49,8 +50,9 @@ func NewState() State {
 			MacroDetailMap:    map[Package]map[string]Macro{},
 			VariableDetailMap: map[string]Variable{},
 		},
-		FusionEnabled: false,
-		FusionPath:    "",
+		FusionEnabled:     false,
+		FusionPath:        "",
+		LspClientRootPath: "",
 	}
 }
 
@@ -113,7 +115,7 @@ func (s *State) parseDocument(uri, text string) {
 }
 
 func (s *State) OpenDocument(uri, text string) {
-	s.refreshDbtContext("")
+	s.refreshDbtContext(s.LspClientRootPath)
 	s.parseDocument(uri, text)
 }
 
@@ -191,7 +193,7 @@ func (s *State) applyIncrementalChange(text string, change lsp.TextDocumentConte
 }
 
 func (s *State) SaveDocument(uri string) {
-	s.refreshDbtContext("")
+	s.refreshDbtContext(s.LspClientRootPath)
 }
 
 func (s *State) Hover(id int, uri string, position lsp.Position) lsp.HoverResponse {

--- a/lsp/initialize.go
+++ b/lsp/initialize.go
@@ -9,6 +9,7 @@ type InitializeRequest struct {
 
 type InitializeRequestParams struct {
 	ClientInfo ClientInfo `json:"clientInfo"`
+	RootPath   string     `json:"rootPath"`
 }
 
 type ClientInfo struct {

--- a/main.go
+++ b/main.go
@@ -89,12 +89,15 @@ func handleMessage(logger *log.Logger, writer io.Writer, state *analysis.State, 
 			logger.Printf("Could not parse: %s", err)
 		}
 
-		logger.Printf("Connected to: %s %s",
+		logger.Printf("Connected to: %s %s %s",
 			request.Params.ClientInfo.Name,
-			request.Params.ClientInfo.Version)
+			request.Params.ClientInfo.Version,
+			request.Params.RootPath,
+		)
 
 		msg := lsp.NewInitializeResponse(request.ID)
 		util.WriteResponse(writer, msg)
+		state.LspClientRootPath = request.Params.RootPath
 
 		logger.Print("Sent the reply")
 	case "textDocument/didOpen":

--- a/util/get_project_root.go
+++ b/util/get_project_root.go
@@ -8,6 +8,20 @@ import (
 )
 
 func findFileDir(fileName string, startPath string) (string, error) {
+	ascPath, ascErr := findFileDirAsc(fileName, startPath)
+	if ascErr == nil {
+		return ascPath, nil
+	}
+
+	descPath, descErr := findFileDirDesc(fileName, startPath)
+	if descErr != nil {
+		return "", descErr
+	}
+
+	return descPath, nil
+}
+
+func findFileDirAsc(fileName string, startPath string) (string, error) {
 	path := startPath
 	for {
 		files, err := os.ReadDir(path)
@@ -26,6 +40,29 @@ func findFileDir(fileName string, startPath string) (string, error) {
 
 		path = filepath.Dir(path)
 	}
+}
+
+func findFileDirDesc(fileName string, startPath string) (string, error) {
+	dirQueue := []string{startPath}
+	for len(dirQueue) > 0 {
+		path := dirQueue[0]
+		dirQueue = dirQueue[1:]
+
+		dirEntries, err := os.ReadDir(path)
+		if err != nil {
+			return "", err
+		}
+
+		for _, entry := range dirEntries {
+			if entry.Name() == fileName {
+				return path, nil
+			} else if entry.IsDir() {
+				dirQueue = append(dirQueue, filepath.Join(path, entry.Name()))
+			}
+		}
+	}
+
+	return "", fmt.Errorf("fileName not found in descending search.")
 }
 
 func GetProjectRoot(projFile string, wd string) string {


### PR DESCRIPTION
Existing implementation only searches ascending through the file system to find the dbt project root. This handles cases where a use opens a file from a directory deep in the project. What is not supported is if an lsp starts from a parent directory like a monorepo.

This PR adds a subsequent descending search that will be attempted if the ascending search is unsuccessful. It will start from the rootPath from the LSP client that is sent with the initialize request.

resolves #12 