### PR TITLE
Add Windows support

### DIFF
--- a/analysis/dbtcore_context.go
+++ b/analysis/dbtcore_context.go
@@ -1,0 +1,141 @@
+package analysis
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/j-clemons/dbt-language-server/lsp"
+)
+
+// buildContextFromManifest converts a dbt manifest into the same in-memory
+// maps the static analysis uses. originalFilePath values in the manifest are
+// relative to the package root; for the main project they resolve against
+// projectRoot, for installed packages against
+// <projectRoot>/<packagesInstallPath>/<packageName>.
+func buildContextFromManifest(
+	m *Manifest,
+	projectRoot string,
+	projYaml DbtProjectYaml,
+) (map[string]ModelDetails, map[string]Source, map[Package]map[string]Macro) {
+	mainProject := projYaml.ProjectName.Value
+	packagesInstallPath := projYaml.PackagesInstallPath.Value
+	if packagesInstallPath == "" {
+		packagesInstallPath = "dbt_packages"
+	}
+
+	resolvePath := func(pkgName, relPath string) string {
+		if pkgName == mainProject {
+			return filepath.Join(projectRoot, relPath)
+		}
+		return filepath.Join(projectRoot, packagesInstallPath, pkgName, relPath)
+	}
+
+	resolvePatchPath := func(pkgName, patchPath string) string {
+		if patchPath == "" {
+			return ""
+		}
+		// format: "package_name://relative/path/to/schema.yml"
+		if idx := strings.Index(patchPath, "://"); idx >= 0 {
+			rel := patchPath[idx+3:]
+			if pkgName == mainProject {
+				return filepath.Join(projectRoot, rel)
+			}
+			return filepath.Join(projectRoot, packagesInstallPath, pkgName, rel)
+		}
+		return ""
+	}
+
+	modelMap := make(map[string]ModelDetails)
+	sourceMap := make(map[string]Source)
+	macroMap := make(map[Package]map[string]Macro)
+
+	// Models and seeds
+	for _, node := range m.Nodes {
+		if node.ResourceType != "model" && node.ResourceType != "seed" {
+			continue
+		}
+
+		absPath := resolvePath(node.PackageName, node.OriginalFilePath)
+		schemaURI := resolvePatchPath(node.PackageName, node.PatchPath)
+
+		name := node.Name
+		if node.Config.Alias != nil && *node.Config.Alias != "" {
+			name = *node.Config.Alias
+		}
+
+		modelMap[name] = ModelDetails{
+			URI:         absPath,
+			ProjectName: node.PackageName,
+			Description: node.Description,
+			SchemaURI:   schemaURI,
+			SchemaRange: lsp.Range{},
+		}
+	}
+
+	// Sources — grouped by source_name so the existing lookup works
+	// (SourceDetailMap[sourceName].Tables[tableName])
+	groupedSources := make(map[string]*Source)
+	for _, src := range m.Sources {
+		absPath := resolvePath(src.PackageName, src.OriginalFilePath)
+
+		if _, ok := groupedSources[src.SourceName]; !ok {
+			groupedSources[src.SourceName] = &Source{
+				Name:        src.SourceName,
+				Description: src.Description,
+				URI:         absPath,
+				Range:       lsp.Range{},
+				Tables:      make(map[string]SourceTable),
+			}
+		}
+
+		groupedSources[src.SourceName].Tables[src.Name] = SourceTable{
+			Name:        src.Name,
+			Description: src.Description,
+			Table:       src.Name,
+			URI:         absPath,
+			Range:       lsp.Range{},
+		}
+	}
+	for k, v := range groupedSources {
+		sourceMap[k] = *v
+	}
+
+	// Macros
+	for _, macro := range m.Macros {
+		pkg := Package(macro.PackageName)
+		if macroMap[pkg] == nil {
+			macroMap[pkg] = make(map[string]Macro)
+		}
+
+		absPath := resolvePath(macro.PackageName, macro.OriginalFilePath)
+
+		desc := macro.Description
+		if len(macro.Arguments) > 0 {
+			parts := make([]string, 0, len(macro.Arguments))
+			for _, arg := range macro.Arguments {
+				if arg.Description != "" {
+					parts = append(parts, fmt.Sprintf("%s: %s", arg.Name, arg.Description))
+				} else {
+					parts = append(parts, arg.Name)
+				}
+			}
+			suffix := "Arguments: " + strings.Join(parts, ", ")
+			if desc != "" {
+				desc += "\n\n" + suffix
+			} else {
+				desc = suffix
+			}
+		}
+
+		macroMap[pkg][macro.Name] = Macro{
+			Name:        macro.Name,
+			ProjectName: pkg,
+			Description: desc,
+			URI:         absPath,
+			Range:       lsp.Range{},
+		}
+	}
+
+	return modelMap, sourceMap, macroMap
+}

--- a/analysis/dbtcore_manifest.go
+++ b/analysis/dbtcore_manifest.go
@@ -1,0 +1,65 @@
+package analysis
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Manifest represents the dbt manifest.json artifact written by `dbt parse`
+// or `dbt compile`.
+type Manifest struct {
+	Nodes   map[string]ManifestNode   `json:"nodes"`
+	Sources map[string]ManifestSource `json:"sources"`
+	Macros  map[string]ManifestMacro  `json:"macros"`
+}
+
+type ManifestNode struct {
+	UniqueID         string             `json:"unique_id"`
+	Name             string             `json:"name"`
+	Description      string             `json:"description"`
+	OriginalFilePath string             `json:"original_file_path"`
+	ResourceType     string             `json:"resource_type"`
+	PackageName      string             `json:"package_name"`
+	PatchPath        string             `json:"patch_path"`
+	Config           ManifestNodeConfig `json:"config"`
+}
+
+type ManifestNodeConfig struct {
+	Alias *string `json:"alias"`
+}
+
+type ManifestSource struct {
+	UniqueID         string `json:"unique_id"`
+	Name             string `json:"name"`
+	SourceName       string `json:"source_name"`
+	Description      string `json:"description"`
+	OriginalFilePath string `json:"original_file_path"`
+	PackageName      string `json:"package_name"`
+}
+
+type ManifestMacro struct {
+	UniqueID         string                  `json:"unique_id"`
+	Name             string                  `json:"name"`
+	Description      string                  `json:"description"`
+	OriginalFilePath string                  `json:"original_file_path"`
+	PackageName      string                  `json:"package_name"`
+	Arguments        []ManifestMacroArgument `json:"arguments"`
+}
+
+type ManifestMacroArgument struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+func readManifest(projectRoot string) (*Manifest, error) {
+	data, err := os.ReadFile(filepath.Join(projectRoot, "target", "manifest.json"))
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}

--- a/analysis/dbtcore_parse.go
+++ b/analysis/dbtcore_parse.go
@@ -1,0 +1,33 @@
+package analysis
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"time"
+)
+
+const dbtParseTimeout = 120 * time.Second
+
+// runDbtParse executes `<dbtPath> parse --project-dir <projectRoot>` and
+// waits up to dbtParseTimeout for it to finish. Any output is written to
+// logger.
+func runDbtParse(dbtPath, projectRoot string, logger *log.Logger) error {
+	ctx, cancel := context.WithTimeout(context.Background(), dbtParseTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, dbtPath, "parse", "--project-dir", projectRoot)
+
+	out, err := cmd.CombinedOutput()
+	if len(out) > 0 {
+		logger.Printf("dbt parse: %s", out)
+	}
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("dbt parse timed out after %s", dbtParseTimeout)
+		}
+		return fmt.Errorf("dbt parse failed: %w", err)
+	}
+	return nil
+}

--- a/analysis/parse_dbt_yaml.go
+++ b/analysis/parse_dbt_yaml.go
@@ -206,11 +206,11 @@ func parseYamlModels(projectRoot string, projYaml DbtProjectYaml) (map[string]Mo
 	docsMap := processDocsFiles(docsFiles)
 
 	for _, path := range projYaml.ModelPaths.Value {
-		_, err := os.ReadDir(projectRoot + "/" + path)
+		_, err := os.ReadDir(filepath.Join(projectRoot, path))
 		if err != nil {
 			continue
 		}
-		files, _ := util.WalkFilepath(projectRoot+"/"+path+"/", ".yml")
+		files, _ := util.WalkFilepath(filepath.Join(projectRoot, path), ".yml")
 		for _, file := range files {
 			dbtYml := parsePropertiesYamlFile(file)
 			for _, model := range dbtYml.Models {

--- a/analysis/parse_macros.go
+++ b/analysis/parse_macros.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -57,7 +58,7 @@ func parseMacros(projectRoot string, dbtProjectYaml DbtProjectYaml) ([]Macro, er
 
 	var err error
 	for _, p := range dbtProjectYaml.MacroPaths.Value {
-		path := projectRoot + "/" + p
+		path := filepath.Join(projectRoot, p)
 		_, err = os.ReadDir(path)
 		if err != nil {
 			continue

--- a/analysis/state.go
+++ b/analysis/state.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -20,6 +21,15 @@ type State struct {
 	FusionEnabled     bool
 	FusionPath        string
 	LspClientRootPath string
+	// DbtCorePath, when non-empty, enables the dbt-core backend: manifest.json
+	// is read from <project_root>/target/manifest.json and used in place of
+	// the static file parser for models, sources and macros.
+	DbtCorePath string
+	// DbtCoreRunOnSave, when true, executes `dbt parse` on every save before
+	// reading the manifest so the data is always current. Requires DbtCorePath.
+	DbtCoreRunOnSave bool
+	// logger is used by the dbt-core parse runner; set during initialisation.
+	logger *log.Logger
 }
 
 type Document struct {
@@ -53,7 +63,13 @@ func NewState() State {
 		FusionEnabled:     false,
 		FusionPath:        "",
 		LspClientRootPath: "",
+		DbtCorePath:      "",
+		DbtCoreRunOnSave: false,
 	}
+}
+
+func (s *State) SetLogger(logger *log.Logger) {
+	s.logger = logger
 }
 
 func (s *State) SetFusionEnabled(enabled bool) {
@@ -74,13 +90,46 @@ func (s *State) refreshDbtContext(wd string) {
 	s.DbtContext.ProjectYaml = parseDbtProjectYaml(s.DbtContext.ProjectRoot)
 	s.DbtContext.Dialect = util.GetDialect(s.DbtContext.ProjectYaml.Profile.Value, wd)
 
+	logger := s.logger
+	if logger == nil {
+		logger = log.New(log.Writer(), "", log.LstdFlags)
+	}
+
 	var wg sync.WaitGroup
-	wg.Add(3)
 
 	var modelMap map[string]ModelDetails
 	var sourceMap map[string]Source
 	var macroMap map[Package]map[string]Macro
 	var varMap map[string]Variable
+
+	if s.DbtCorePath != "" {
+		// dbt-core mode: optionally refresh the manifest then read it.
+		if s.DbtCoreRunOnSave {
+			if err := runDbtParse(s.DbtCorePath, s.DbtContext.ProjectRoot, logger); err != nil {
+				logger.Printf("dbt-core: %v", err)
+			}
+		}
+
+		manifest, err := readManifest(s.DbtContext.ProjectRoot)
+		if err == nil {
+			modelMap, sourceMap, macroMap = buildContextFromManifest(
+				manifest,
+				s.DbtContext.ProjectRoot,
+				s.DbtContext.ProjectYaml,
+			)
+			// Variables are not stored in the manifest; always use static parser.
+			varMap = s.getProjectVariables()
+			s.DbtContext.ModelDetailMap = modelMap
+			s.DbtContext.SourceDetailMap = sourceMap
+			s.DbtContext.MacroDetailMap = macroMap
+			s.DbtContext.VariableDetailMap = varMap
+			return
+		}
+		logger.Printf("dbt-core: manifest not found (%v), falling back to static analysis", err)
+	}
+
+	// Static analysis (default path, or fallback when manifest is absent).
+	wg.Add(3)
 
 	go func() {
 		defer wg.Done()

--- a/analysis/state.go
+++ b/analysis/state.go
@@ -287,7 +287,7 @@ func (s *State) Definition(id int, uri string, position lsp.Position) lsp.Defini
 	case parser.REF:
 		model := s.DbtContext.ModelDetailMap[cursorToken.Literal]
 		if model != (ModelDetails{}) {
-			response.Result.URI = "file://" + model.URI
+			response.Result.URI = util.PathToFileURI(model.URI)
 			response.Result.Range = lsp.Range{
 				Start: lsp.Position{
 					Line:      0,
@@ -302,7 +302,7 @@ func (s *State) Definition(id int, uri string, position lsp.Position) lsp.Defini
 	case parser.SOURCE:
 		source := s.DbtContext.SourceDetailMap[cursorToken.Literal]
 		if source.Name != "" {
-			response.Result.URI = "file://" + source.URI
+			response.Result.URI = util.PathToFileURI(source.URI)
 			response.Result.Range = source.Range
 		}
 	case parser.SOURCE_TABLE:
@@ -310,14 +310,14 @@ func (s *State) Definition(id int, uri string, position lsp.Position) lsp.Defini
 		if match {
 			source := s.DbtContext.SourceDetailMap[tokenLiteral].Tables[cursorToken.Literal]
 			if source.Name != "" {
-				response.Result.URI = "file://" + source.URI
+				response.Result.URI = util.PathToFileURI(source.URI)
 				response.Result.Range = source.Range
 			}
 		}
 	case parser.VAR:
 		variable := s.DbtContext.VariableDetailMap[cursorToken.Literal]
 		if variable != (Variable{}) {
-			response.Result.URI = "file://" + variable.URI
+			response.Result.URI = util.PathToFileURI(variable.URI)
 			response.Result.Range = variable.Range
 		}
 	case parser.MACRO:
@@ -328,7 +328,7 @@ func (s *State) Definition(id int, uri string, position lsp.Position) lsp.Defini
 		}
 		macro := s.DbtContext.MacroDetailMap[packageName][cursorToken.Literal]
 		if macro != (Macro{}) {
-			response.Result.URI = "file://" + macro.URI
+			response.Result.URI = util.PathToFileURI(macro.URI)
 			response.Result.Range = macro.Range
 		}
 	default:
@@ -373,7 +373,7 @@ func (s *State) GoToSchema(id int, uri string, position lsp.Position) lsp.Execut
 				model, modelExists := s.DbtContext.ModelDetailMap[cursorToken.Literal]
 				if modelExists && model.SchemaURI != "" {
 					response.Result = lsp.Location{
-						URI:   "file://" + model.SchemaURI,
+						URI:   util.PathToFileURI(model.SchemaURI),
 						Range: model.SchemaRange,
 					}
 					return response
@@ -389,7 +389,7 @@ func (s *State) GoToSchema(id int, uri string, position lsp.Position) lsp.Execut
 		model, modelExists := s.DbtContext.ModelDetailMap[modelName]
 		if modelExists && model.SchemaURI != "" {
 			response.Result = lsp.Location{
-				URI:   "file://" + model.SchemaURI,
+				URI:   util.PathToFileURI(model.SchemaURI),
 				Range: model.SchemaRange,
 			}
 		}
@@ -398,8 +398,7 @@ func (s *State) GoToSchema(id int, uri string, position lsp.Position) lsp.Execut
 }
 
 func getModelNameFromURI(uri string) string {
-	// Remove file:// prefix if present
-	cleanURI := strings.TrimPrefix(uri, "file://")
+	cleanURI := util.FileURIToPath(uri)
 
 	// Get the base filename without extension
 	baseName := filepath.Base(cleanURI)

--- a/build-all-platforms.sh
+++ b/build-all-platforms.sh
@@ -5,11 +5,11 @@ DIST_DIR="dist"
 mkdir -p "$DIST_DIR"
 
 # Define target platforms
-# "windows/amd64" is not fully supported
 PLATFORMS=(
     "darwin/amd64"
     "darwin/arm64"
     "linux/amd64"
+    "windows/amd64"
 )
 
 LDFLAGS="-X github.com/j-clemons/dbt-language-server/version.Version=${VERSION:-dev}"

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,85 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs the latest dbt-language-server release on Windows.
+.DESCRIPTION
+    Downloads the appropriate binary from GitHub releases and installs it to
+    $env:LOCALAPPDATA\Programs\dbt-language-server, then offers to add that
+    directory to the user's PATH.
+.EXAMPLE
+    irm https://raw.githubusercontent.com/j-clemons/dbt-language-server/main/install.ps1 | iex
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Repo    = 'j-clemons/dbt-language-server'
+$ApiUrl  = "https://api.github.com/repos/$Repo/releases/latest"
+
+# Detect architecture
+$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    'AMD64' { 'amd64' }
+    'ARM64' { 'arm64' }
+    default {
+        Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE. Only AMD64 and ARM64 are supported."
+        exit 1
+    }
+}
+
+$BinaryName  = "dbt-language-server-windows-$arch.exe"
+$InstallDir  = Join-Path $env:LOCALAPPDATA 'Programs\dbt-language-server'
+$InstallPath = Join-Path $InstallDir 'dbt-language-server.exe'
+
+Write-Host "Installing $BinaryName to $InstallPath..."
+
+# Fetch latest release metadata
+try {
+    $Release = Invoke-RestMethod -Uri $ApiUrl -UseBasicParsing
+} catch {
+    Write-Error "Failed to fetch release information from GitHub: $_"
+    exit 1
+}
+
+# Find the matching asset
+$Asset = $Release.assets | Where-Object { $_.name -eq $BinaryName } | Select-Object -First 1
+if (-not $Asset) {
+    Write-Error "Binary '$BinaryName' not found in the latest release."
+    exit 1
+}
+
+$DownloadUrl = $Asset.browser_download_url
+
+# Create install directory
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir | Out-Null
+}
+
+# Download the binary
+$TempFile = [System.IO.Path]::GetTempFileName() + '.exe'
+try {
+    Invoke-WebRequest -Uri $DownloadUrl -OutFile $TempFile -UseBasicParsing
+} catch {
+    Write-Error "Failed to download binary: $_"
+    exit 1
+}
+
+# Move to install location
+Move-Item -Force -Path $TempFile -Destination $InstallPath
+
+Write-Host "Installation complete: $InstallPath"
+
+# Offer to add install directory to the user PATH if not already present
+$UserPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+if ($UserPath -split ';' -notcontains $InstallDir) {
+    $AddToPath = Read-Host "Add '$InstallDir' to your user PATH? [Y/n]"
+    if ($AddToPath -eq '' -or $AddToPath -match '^[Yy]') {
+        $NewPath = ($UserPath.TrimEnd(';') + ';' + $InstallDir).TrimStart(';')
+        [Environment]::SetEnvironmentVariable('PATH', $NewPath, 'User')
+        $env:PATH = $env:PATH.TrimEnd(';') + ';' + $InstallDir
+        Write-Host "PATH updated. Restart your terminal for the change to take effect."
+    }
+} else {
+    Write-Host "'$InstallDir' is already in your PATH."
+}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"os/exec"
 
 	flag "github.com/spf13/pflag"
 
@@ -21,10 +20,7 @@ import (
 
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "upgrade" {
-		cmd := exec.Command("bash", "-c", "curl -fsSL https://raw.githubusercontent.com/j-clemons/dbt-language-server/main/install | bash")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
+		if err := util.Upgrade(); err != nil {
 			log.Fatal("Upgrade failed:", err)
 		}
 		os.Exit(0)

--- a/main.go
+++ b/main.go
@@ -32,6 +32,11 @@ func main() {
 	fusion := flag.StringP("fusion", "f", "", "Enable dbt fusion features. Provide an absolute path if default value is not dbt")
 	flag.Lookup("fusion").NoOptDefVal = "dbt"
 
+	dbtCore := flag.StringP("dbt-core", "c", "", "Enable dbt-core backend: read manifest.json for richer metadata. Optionally provide the path to the dbt binary (default: 'dbt')")
+	flag.Lookup("dbt-core").NoOptDefVal = "dbt"
+
+	dbtCoreParse := flag.BoolP("dbt-core-parse", "p", false, "Run 'dbt parse' on every save to keep the manifest current (requires --dbt-core)")
+
 	flag.Parse()
 
 	if *showVersion {
@@ -47,6 +52,7 @@ func main() {
 	}
 
 	state := analysis.NewState()
+	state.SetLogger(logger)
 	state.FusionEnabled = false
 	state.FusionPath = *fusion
 
@@ -58,6 +64,11 @@ func main() {
 			}
 			state.SetFusionEnabled(fusionValidation)
 		}()
+	}
+
+	if *dbtCore != "" {
+		state.DbtCorePath = *dbtCore
+		state.DbtCoreRunOnSave = *dbtCoreParse
 	}
 
 	logger.Println("dbt Language Server Started!")

--- a/util/get_project_root.go
+++ b/util/get_project_root.go
@@ -34,7 +34,7 @@ func findFileDirAsc(fileName string, startPath string) (string, error) {
 				return path, nil
 			}
 		}
-		if path == "/" {
+		if filepath.Dir(path) == path {
 			return "", fmt.Errorf("File %s not found", fileName)
 		}
 

--- a/util/upgrade.go
+++ b/util/upgrade.go
@@ -1,0 +1,122 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+const releaseAPIURL = "https://api.github.com/repos/j-clemons/dbt-language-server/releases/latest"
+
+type githubRelease struct {
+	Assets []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+// Upgrade downloads and replaces the current binary with the latest release.
+// On Windows the running binary cannot be overwritten, so the new binary is
+// placed alongside it as dbt-language-server-new.exe with instructions to
+// replace manually.
+func Upgrade() error {
+	goos := runtime.GOOS
+	goarch := runtime.GOARCH
+
+	binaryName := fmt.Sprintf("dbt-language-server-%s-%s", goos, goarch)
+	if goos == "windows" {
+		binaryName += ".exe"
+	}
+
+	fmt.Printf("Fetching latest release for %s/%s...\n", goos, goarch)
+
+	resp, err := http.Get(releaseAPIURL)
+	if err != nil {
+		return fmt.Errorf("failed to fetch release info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return fmt.Errorf("failed to parse release info: %w", err)
+	}
+
+	var downloadURL string
+	for _, asset := range release.Assets {
+		if asset.Name == binaryName {
+			downloadURL = asset.BrowserDownloadURL
+			break
+		}
+	}
+	if downloadURL == "" {
+		return fmt.Errorf("binary %s not found in the latest release", binaryName)
+	}
+
+	fmt.Printf("Downloading %s...\n", binaryName)
+	dlResp, err := http.Get(downloadURL)
+	if err != nil {
+		return fmt.Errorf("failed to download binary: %w", err)
+	}
+	defer dlResp.Body.Close()
+
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to determine executable path: %w", err)
+	}
+	exePath, err = filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve symlinks: %w", err)
+	}
+
+	dir := filepath.Dir(exePath)
+
+	if goos == "windows" {
+		// Windows locks the running executable, so write alongside it and ask
+		// the user to replace it after the process exits.
+		newPath := filepath.Join(dir, "dbt-language-server-new.exe")
+		f, err := os.Create(newPath)
+		if err != nil {
+			return fmt.Errorf("failed to create download target: %w", err)
+		}
+		_, err = io.Copy(f, dlResp.Body)
+		f.Close()
+		if err != nil {
+			os.Remove(newPath)
+			return fmt.Errorf("failed to write download: %w", err)
+		}
+		fmt.Printf("\nDownload complete: %s\n", newPath)
+		fmt.Printf("To finish upgrading, replace %s with %s\n", exePath, newPath)
+		return nil
+	}
+
+	// Unix: write to a temp file in the same directory, then atomically rename.
+	tmp, err := os.CreateTemp(dir, "dbt-language-server-upgrade-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	_, err = io.Copy(tmp, dlResp.Body)
+	tmp.Close()
+	if err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to write download: %w", err)
+	}
+
+	if err := os.Chmod(tmpPath, 0755); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to set permissions: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, exePath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to replace binary: %w", err)
+	}
+
+	fmt.Println("Upgrade complete!")
+	return nil
+}

--- a/util/uri.go
+++ b/util/uri.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// PathToFileURI converts a native filesystem path to an LSP file URI.
+// On Windows, backslashes are converted to forward slashes and the drive
+// letter is separated correctly (file:///C:/path), matching the LSP spec.
+func PathToFileURI(path string) string {
+	if runtime.GOOS == "windows" {
+		path = filepath.ToSlash(path)
+		return "file:///" + strings.TrimPrefix(path, "/")
+	}
+	return "file://" + path
+}
+
+// FileURIToPath converts an LSP file URI to a native filesystem path.
+// Handles the extra leading slash that Windows URIs carry (file:///C:/...).
+func FileURIToPath(uri string) string {
+	path := strings.TrimPrefix(uri, "file://")
+	if runtime.GOOS == "windows" {
+		path = strings.TrimPrefix(path, "/")
+		path = filepath.FromSlash(path)
+	}
+	return path
+}


### PR DESCRIPTION
- Replace hardcoded "/" path separators with filepath.Join in parse_macros.go and parse_dbt_yaml.go so file discovery works on Windows
- Fix filesystem root detection in get_project_root.go: use filepath.Dir(path) == path instead of path == "/" so ascending search terminates correctly on Windows drive roots (C:\, D:\, etc.)
- Add util/uri.go with PathToFileURI / FileURIToPath helpers that handle the extra leading slash in Windows file URIs (file:///C:/path); update all definition/schema URI construction in state.go to use them
- Replace the bash+curl upgrade command with a pure Go implementation in util/upgrade.go that works on all platforms; on Windows the running .exe cannot be replaced in-place so the new binary is downloaded alongside it with instructions to swap manually
- Add windows/amd64 to build-all-platforms.sh and remove the "not fully supported" comment
- Add install.ps1: PowerShell install script for Windows that mirrors the bash install script (detects arch, fetches latest GitHub release, installs to %LOCALAPPDATA%\Programs\dbt-language-server, offers to update PATH)